### PR TITLE
Use the atom-text-editor tag instead of the editor class

### DIFF
--- a/stylesheets/select-list.less
+++ b/stylesheets/select-list.less
@@ -14,7 +14,7 @@
   color: @select-list-color;
   box-shadow: 0 7px 10px 0 @select-list-shadow;
 
-  .editor {
+  atom-text-editor {
     border: 1px solid @select-list-editor-border;
     box-shadow: 0 0 5px 0 @select-list-editor-shadow;
     border-radius: 2px;


### PR DESCRIPTION
Fix this warning:
Use the atom-text-editor tag instead of the editor class
